### PR TITLE
docs: fix a broken link (Slack invite)

### DIFF
--- a/docs/modules/ROOT/pages/part1/rules.adoc
+++ b/docs/modules/ROOT/pages/part1/rules.adoc
@@ -263,7 +263,7 @@ Gitter with your GitHub account.
 If you prefer, you can also use the project's Slack channel at
 https://owasp.slack.com/messages/project-juiceshop. You just need to
 self-invite you to OWASP's Slack first at
-https://owasp-slack.herokuapp.com. If you like it a bit more
+https://owasp.org/slack/invite. If you like it a bit more
 nostalgic, you can also join and post to the project Google
 group/mailing list at
 https://groups.google.com/a/owasp.org/forum/#!forum/juice-shop-project.


### PR DESCRIPTION
The Slack self-invite link is returning Heroku 404 error. My guess is that the original Heroku Slack self-invite page was migrated to OWASP's own domain. This commit replaces the link with the correct one.

Original: https://owasp-slack.herokuapp.com
This commit: https://owasp.org/slack/invite