### PR TITLE
docs: update iframe xss in solutions.adoc

### DIFF
--- a/docs/modules/ROOT/pages/appendix/solutions.adoc
+++ b/docs/modules/ROOT/pages/appendix/solutions.adoc
@@ -175,7 +175,7 @@ the navigation bar.
 
 === Perform a DOM XSS attack
 
-. Paste the attack string `<iframe src="javascript:alert(`xss`)">`
+. Paste the attack string `<iframe src="javascript:alert('xss')">`
 into the _Search..._ field.
 . Hit the Enter key.
 . An alert box with the text "xss" should appear.


### PR DESCRIPTION
The original code snippet is presented incorrectly in the docs so copying it as is doesn't fulfil the tutorial needs.

Original: `<iframe src="javascript:alert(`xss`)">`
Change: `<iframe src="javascript:alert('xss')">`